### PR TITLE
Fix docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # the-visibility-report-api
-  
+
 ## Running
 
-docker-compose up
+docker compose up
+
+### Windows
+
+Note, if editing `init.sh` ensure that you are using Linux line endings (LF) 
 
 ## Deploying
 
@@ -10,5 +14,5 @@ Change mode to development/prod
 
 ## Routes
 
-GET api/v1/hb -> return a heartbeat of the system  
-GET api/v1/countries/rankings -> return a ranked listed of countries  
+GET api/v1/hb -> return a heartbeat of the system
+GET api/v1/countries/rankings -> return a ranked listed of countries

--- a/The Visibility Report.postman_collection.json
+++ b/The Visibility Report.postman_collection.json
@@ -1,0 +1,81 @@
+{
+	"info": {
+		"_postman_id": "3ebab33e-2234-4ffa-8532-5bcfcdac5f3d",
+		"name": "The Visibility Report",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Heart Beat",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{baseUrl}}/api/v1/hb",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"api",
+						"v1",
+						"hb"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Blocked Sites by Country",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{baseUrl}}/api/v1/blockedwebsites/:countryname",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"api",
+						"v1",
+						"blockedwebsites",
+						":countryname"
+					],
+					"variable": [
+						{
+							"key": "countryname",
+							"value": "Australia"
+						}
+					]
+				}
+			},
+			"response": []
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"key": "baseUrl",
+			"value": "http://localhost:1323",
+			"type": "string"
+		}
+	]
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: .
     volumes:
       - '.:/app'
-    command: [ "./init.sh" ]
+    entrypoint: [ "sh","./init.sh" ]
     ports:
       - "1323:1323"
     environment:


### PR DESCRIPTION
Getting issue below running `docker compose up`, cannot find `init.sh` in built image. Updated Docker compose to use `entrypoint` rather than `command` 

```
tvr-api                         | standard_init_linux.go:228: exec user process caused: no such file or directory
tvr-api exited with code 1
```

